### PR TITLE
[18.08] Bump node to 10.17.0

### DIFF
--- a/org.freedesktop.Sdk.Extension.node10.yaml
+++ b/org.freedesktop.Sdk.Extension.node10.yaml
@@ -12,8 +12,8 @@ modules:
   - name: node
     sources:
       - type: archive
-        url: https://nodejs.org/dist/v10.16.3/node-v10.16.3.tar.gz
-        sha256: db5a5e03a815b84a1266a4b48bb6a6d887175705f84fd2472f0d28e5e305a1f8
+        url: https://nodejs.org/dist/v10.17.0/node-v10.17.0.tar.xz
+        sha256: 412667d76bd5273c07cb69c215998109fd5bb35c874654f93e6a0132d666c58e
 
   - name: scripts
     buildsystem: simple


### PR DESCRIPTION
Also switch to .tar.xz which is smaller

Cherrypick of a21f40ff8f976c8dd4c085a7b97966ee1629c974