### PR TITLE
Change configure flags to make more use of system libs

### DIFF
--- a/org.freedesktop.Sdk.Extension.node10.yaml
+++ b/org.freedesktop.Sdk.Extension.node10.yaml
@@ -26,6 +26,11 @@ modules:
       - type: archive
         url: https://nodejs.org/dist/v10.17.0/node-v10.17.0.tar.xz
         sha256: 412667d76bd5273c07cb69c215998109fd5bb35c874654f93e6a0132d666c58e
+    config-opts:
+      - '--openssl-use-def-ca-store'
+      - '--shared-openssl'
+      - '--shared-zlib'
+      - '--with-intl=system-icu'
 
   - name: scripts
     buildsystem: simple


### PR DESCRIPTION
Build with system OpenSSL, to ensure that security fixes in the
runtime are picked up, and CA certificates from the host are available.

Build with system ICU, otherwise the default is small-icu, which
is broken.

Build with system zlib, because we can and it reduces the binary size.