### PR TITLE
Strip binaries

### DIFF
--- a/org.freedesktop.Sdk.Extension.node10.yaml
+++ b/org.freedesktop.Sdk.Extension.node10.yaml
@@ -10,6 +10,7 @@ build-options:
   prefix: /usr/lib/sdk/node10
   prepend-path: /usr/lib/sdk/node10/bin
   prepend-ld-library-path: /usr/lib/sdk/node10/lib
+  strip: true
 cleanup:
   - /bin/pip*
   - /bin/python*config


### PR DESCRIPTION
Currently, this SDK extension is more than 800MiB. Stripping can reduce it's size by a huge amount.